### PR TITLE
Bump default buffer size to 2048 bytes

### DIFF
--- a/src/contig_buffer.rs
+++ b/src/contig_buffer.rs
@@ -1,6 +1,6 @@
 use core::{fmt, slice::Chunks};
 
-const BUFF_SZ: usize = 1024;
+const BUFF_SZ: usize = 2048;
 const CHUNK_SZ: usize = 512;
 #[derive(Debug)]
 pub(crate) struct Buffer {


### PR DESCRIPTION
1024 doesn't seem to be sufficient for some MP3s

examples/easymode_wave gets EasyModeErr::InDataUnderflow and isn't able to recover.