### PR TITLE
ID3 detection fixes

### DIFF
--- a/src/easy_mode.rs
+++ b/src/easy_mode.rs
@@ -11,6 +11,8 @@ pub struct EasyMode {
     sync: bool,
     have_decoded: bool,
     parsed_id3: bool,
+    /// True when the stream began with an ID3v2 tag skipped by header size.
+    id3_skipped: bool,
     bytes_to_skip: usize,
     frame_info: Option<MP3FrameInfo>,
 }
@@ -30,9 +32,29 @@ impl EasyMode {
             sync: false,
             have_decoded: false,
             parsed_id3: false,
+            id3_skipped: false,
             bytes_to_skip: 0,
             frame_info: None,
         }
+    }
+
+    /// After ID3 skip or at the start of raw MP3 data, align to the next frame.
+    fn sync_to_frame(&mut self) -> bool {
+        if self.sync {
+            return true;
+        }
+        if self.id3_skipped {
+            match self.mp3.get_next_frame_info(self.buffer.borrow_slice()) {
+                Ok(frame) => {
+                    self.frame_info = Some(frame);
+                    self.sync = true;
+                }
+                Err(_) => return false,
+            }
+        } else {
+            self.skip_to_next_sync_word();
+        }
+        self.sync
     }
 
     /// Add MP3 data to the EasyMode internal MP3 stream buffer.
@@ -52,7 +74,6 @@ impl EasyMode {
                 let f = self.mp3.get_next_frame_info(self.buffer.borrow_slice());
                 if let Ok(frame) = f {
                     self.frame_info = Some(frame);
-                    self.have_decoded = true;
                 }
             } else {
                 // Could not sync with any of the data in the buffer, so most of the data is useless.
@@ -80,32 +101,31 @@ impl EasyMode {
         to_remove
     }
 
-    /// Skip over ID3 and anything else at the start of an MP3 stream.
-    /// Returns true when we've got a valid MP3 frame
+    /// Skip over ID3 and align to the first MP3 frame.
+    ///
+    /// Returns true when a valid frame header is available. After an ID3v2 tag,
+    /// alignment uses the tag size from the header because tag bodies 
+    /// can contain false MPEG sync bytes.
     pub fn mp3_decode_ready(&mut self) -> bool {
         if self.buffer_used() == 0 {
-            false
-        } else {
-            if !self.parsed_id3 {
-                self.parsed_id3 = true;
-                let id3 = Mp3::find_id3v2(self.buffer.borrow_slice());
-                self.bytes_to_skip = if let Some(id3) = id3 {
-                    // start of header + size of header + length of id3v2 info
-                    id3.0 + 10 + id3.1.size
-                } else {
-                    0
-                };
-            };
-            if self.bytes_to_skip > 0 {
-                let bytes_to_skip = core::cmp::min(self.buffer_used(), self.bytes_to_skip);
-                self.buffer_skip(bytes_to_skip);
-                self.bytes_to_skip -= bytes_to_skip;
-            } else {
-                let _ = self.skip_to_next_sync_word();
-            }
-
-            self.parsed_id3 && self.bytes_to_skip == 0 && self.sync
+            return false;
         }
+        if !self.parsed_id3 {
+            self.parsed_id3 = true;
+            if let Some((offset, id3)) = Mp3::find_id3v2(self.buffer.borrow_slice()) {
+                self.id3_skipped = true;
+                self.bytes_to_skip = id3.skip_len(offset);
+            }
+        }
+        if self.bytes_to_skip > 0 {
+            let bytes_to_skip = core::cmp::min(self.buffer_used(), self.bytes_to_skip);
+            self.buffer_skip(bytes_to_skip);
+            self.bytes_to_skip -= bytes_to_skip;
+            if self.bytes_to_skip > 0 {
+                return false;
+            }
+        }
+        self.sync_to_frame()
     }
 
     /// Decode the next MP3 audio frame after checking that the output buffer is large enough

--- a/src/mp3.rs
+++ b/src/mp3.rs
@@ -54,6 +54,19 @@ pub struct Id3v2 {
     pub size: usize,
 }
 
+impl Id3v2 {
+    /// Bytes to skip from the start of a buffer to reach audio after this tag.
+    ///
+    /// `header_offset` is the index of the `ID3` magic in the buffer.
+    pub fn skip_len(&self, header_offset: usize) -> usize {
+        let mut skip = header_offset + 10 + self.size;
+        if self.flags.footer_present {
+            skip += 10;
+        }
+        skip
+    }
+}
+
 impl MP3FrameInfo {
     pub fn new() -> MP3FrameInfo {
         MP3FrameInfo {

--- a/src/mp3.rs
+++ b/src/mp3.rs
@@ -39,7 +39,7 @@ pub enum Id3v2Version {
     ID3v2_3,
     /// ID3v2.4
     ID3v2_4,
-    /// Major version isn't 2 and minor version isn't 0-4, unknown or invalid version
+    /// Unrecognized major/minor version bytes
     Invalid,
 }
 
@@ -288,9 +288,10 @@ impl Mp3 {
         for (offset, slice) in window.enumerate() {
             if let [b'I', b'D', b'3', major, minor, flags, s1, s2, s3, s4] = slice {
                 let version = match (major, minor) {
-                    (2, 2) => Id3v2Version::ID3v2_2,
-                    (2, 3) => Id3v2Version::ID3v2_3,
-                    (2, 4) => Id3v2Version::ID3v2_4,
+                    (2, 0) => Id3v2Version::ID3v2_2,
+                    (2, 1) => Id3v2Version::ID3v2_1,
+                    (3, 0) => Id3v2Version::ID3v2_3,
+                    (4, 0) => Id3v2Version::ID3v2_4,
                     (_, _) => Id3v2Version::Invalid,
                 };
                 let id3v2_flags = Id3v2Flags {
@@ -299,12 +300,11 @@ impl Mp3 {
                     experimental: flags & 0b0010_0000 == 0b0010_0000,
                     footer_present: flags & 0b0001_0000 == 0b0001_0000,
                 };
-                // Only the top 4 bits are valid flags, the bottom 4 were never used
-                let valid_flags = flags & 0b0000_1111 != 0b0000_1111;
-                // The ID3v2 tag size is stored as a 32 bit synchsafe integer, making a total of 28 effective bits (representing up to 256MB).
-                // a syncsafe integer is a 7bit integer where the top bit is always zero.
-                let valid_syncsafe = (s1 | s2 | s3 | s4) & 0b1000_0000 != 0b1000_0000;
-                if version == Id3v2Version::Invalid && valid_syncsafe && valid_flags {
+                // Only the top 4 bits are valid flags; the bottom 4 are reserved and must be zero.
+                let valid_flags = flags & 0b0000_1111 == 0;
+                // Tag size is a 28-bit synchsafe integer: each byte uses only the low 7 bits.
+                let valid_syncsafe = (s1 | s2 | s3 | s4) & 0b1000_0000 == 0;
+                if version != Id3v2Version::Invalid && valid_syncsafe && valid_flags {
                     let (s1, s2, s3, s4) = (*s1 as usize, *s2 as usize, *s3 as usize, *s4 as usize);
                     let size = s4 | s3 << 7 | s2 << 14 | s1 << 21;
                     return Some((


### PR DESCRIPTION
We weren't decoding ID3 versions correctly, or skipping over them correctly in easymode